### PR TITLE
Made plone.testing compatible with zope.testbrowser 4.x

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,9 @@ Changelog
 - Broke dependency on `unittest2` for Python 2.7+ as all features of
   `unittest2` are integrated in `unittest` there.
 
+- Fixed AttributeError when importing ``plone.testing.z2`` if
+  ``zope.testbrowser`` 4.x is used but not ``zope.app.testing``.
+
 
 4.0.3 (2011-11-24)
 ------------------

--- a/src/plone/testing/_z2_testbrowser.py
+++ b/src/plone/testing/_z2_testbrowser.py
@@ -10,7 +10,9 @@ from cStringIO import StringIO
 import mechanize
 import pkg_resources
 
-import zope.testbrowser.testing
+# Using a from-import here to avoid an AttributeError below when using
+# zope.testbrowser 4.x without zope.app.testing:
+from zope.testbrowser.testing import PublisherConnection, PublisherResponse
 import zope.testbrowser.browser
 
 
@@ -63,7 +65,7 @@ class Zope2HTTPHandler(urllib2.HTTPHandler):
             return Zope2Connection(self.app, host, timeout=timeout)
         return self.do_open(connectionFactory, req)
 
-class Zope2Connection(zope.testbrowser.testing.PublisherConnection):
+class Zope2Connection(PublisherConnection):
     """A urllib2-compatible connection that can talk to the Zope 2 publisher.
     """
     
@@ -105,7 +107,7 @@ class Zope2Connection(zope.testbrowser.testing.PublisherConnection):
         headers = '\r\n'.join('%s: %s' % h for h in headers)
         content = self.response.getBody()
         
-        return zope.testbrowser.testing.PublisherResponse(content, headers, status, reason)
+        return PublisherResponse(content, headers, status, reason)
 
 def saveState(func):
     """Save threadlocal state (security manager, local component site) before


### PR DESCRIPTION
Fixed AttributeError when importing `plone.testing.z2` if `zope.testbrowser` 4.x is used but not `zope.app.testing`.

This fixes https://dev.plone.org/ticket/12195
