### PR TITLE
Fixing unquoting bug.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,8 +4,10 @@ Changelog
 4.0.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Fixed an issue where a query string would be unquoted twice; once
+  while setting up the HTTP request and once in the handler (the
+  publisher).
+  [malthe]
 
 4.0.4 (2012-08-04)
 ------------------

--- a/src/plone/testing/_z2_testbrowser.py
+++ b/src/plone/testing/_z2_testbrowser.py
@@ -172,7 +172,6 @@ class Zope2Caller(object):
         commandLine = requestString[:l].rstrip()
         requestString = requestString[l+1:]
         method, path, protocol = commandLine.split()
-        path = urllib.unquote(path)
         
         instream = StringIO(requestString)
         

--- a/src/plone/testing/z2.txt
+++ b/src/plone/testing/z2.txt
@@ -413,6 +413,18 @@ We can now view this via the test browser:
     >>> 'folder1' in browser.contents
     True
 
+The test browser integration converts the URL into a request and
+passes control to Zope's publisher. Let's check that query strings are
+available for input processing:
+
+    >>> import urllib
+    >>> qs = urllib.urlencode({'foo': 'boo, bar & baz'})  # sic: the ampersand.
+    >>> _ = app['folder1'].addDTMLMethod('index_html', file='<dtml-var foo>')
+    >>> import transaction; transaction.commit()
+    >>> browser.open(app.absolute_url() + '/folder1?' + qs)
+    >>> browser.contents
+    'boo, bar & baz'
+
 The test browser also works with iterators. Let's test that with a simple
 file implementation that uses an iterator.
 


### PR DESCRIPTION
This issue has been discussed in 30adbf469618f3c86fbd553b7fb4422ee30d2e92. Note that the code in question is from Zope 2's `Testing` module.
