### PR TITLE
Raise a useful error if user could not be found.

### DIFF
--- a/src/plone/testing/z2.py
+++ b/src/plone/testing/z2.py
@@ -162,6 +162,8 @@ def login(userFolder, userName):
     from AccessControl.SecurityManagement import newSecurityManager
 
     user = userFolder.getUser(userName)
+    if user is None:
+        raise ValueError('User could not be found')
     if not hasattr(user, 'aq_base'):
         user = user.__of__(userFolder)
     newSecurityManager(None, user)


### PR DESCRIPTION
Instead of the "NoneType has no attribute **of**" error that we usually get.
