### PR TITLE
Really fix not to depend on unittest2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ install_requires = ['setuptools',
                     ]
 
 
-if sys.version < (2, 7):
+if sys.version_info < (2, 7):
     install_requires.append('unittest2')
 
 tests_require = ['zope.component',


### PR DESCRIPTION
The previous fix to drop unittest2 test dependency for Python 2.7 was
wrong. Here comes the correct one.
