### PR TITLE
Pin collective.xmltestreport version

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -3,6 +3,10 @@ extends =
     http://download.zope.org/Zope2/index/2.12.12/versions.cfg
 parts = coverage test report report-xml
 develop = .
+versions = versions
+
+[versions]
+collective.xmltestreport = 1.2.6
 
 [test]
 recipe = collective.xmltestreport


### PR DESCRIPTION
to a suitable one for Zope 2.12.12 used in extends.
