### PR TITLE
Allow mulitple registration functions for product install

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+4.0.14 (unreleased)
+-------------------
+
+- Added ``multiinit``-parameter to z2.installProduct
+  to allow multiple initialize methods for a package
+  [tomgross]
+
 4.0.13 (2015-03-13)
 -------------------
 
@@ -9,7 +16,6 @@ Changelog
 
 - Add tox.ini
   [icemac]
-
 
 4.0.12 (2014-09-07)
 -------------------

--- a/src/plone/testing/z2.py
+++ b/src/plone/testing/z2.py
@@ -26,7 +26,7 @@ except ImportError:
 
 _INSTALLED_PRODUCTS = {}
 
-def installProduct(app, productName, quiet=False):
+def installProduct(app, productName, quiet=False, multiinit=False):
     """Install the Zope 2 product with the given name, so that it will show
     up in the Zope 2 control panel and have its ``initialize()`` hook called.
 
@@ -81,7 +81,8 @@ def installProduct(app, productName, quiet=False):
                 _INSTALLED_PRODUCTS[productName] = (module, init_func,)
 
                 found = True
-                break
+                if not multiinit:
+                    break
 
     if not found and not quiet:
         sys.stderr.write("Could not install product %s\n" % productName)


### PR DESCRIPTION
In some rare cases multiple registration functions are helpful (ie the use of archetypes.configure). This commit introduces a parameter for the installProduct method which allows this behavior. It is set to False by default