### PR TITLE
fix(ex_handling): Don't let finally block mask ex

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 4.0.15 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Prevent exception masking in finally clause of zopeApp context
+  [do3cc]
 
 
 4.0.14 (2015-07-29)


### PR DESCRIPTION
We have a project with test code which utilizes collective.solr which
utilizes collective.indexing which pushes index operations to the
pre commit phase.
In our case an exception was then thrown during commit within
the zopeApp context.
closing the connection in the finally statement raised another exception
because of the unclean state left by the first exception.
This exception in the finally block totally masked the original
exception, hindering bug fixing.

@tisto do you mind if I budge you for a quick review?