### PR TITLE
Break when trying to do commits in integration tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,8 @@ Changelog
 
 New:
 
-- *add item here*
+- Refuse to work if user breaks test isolation.
+  [do3cc]
 
 Fixes:
 

--- a/src/plone/testing/z2.py
+++ b/src/plone/testing/z2.py
@@ -817,7 +817,7 @@ class IntegrationTesting(Layer):
 
         def you_broke_it():
             raise TestIsolationBroken(
-        """You are in a Test Layer (FunctionalTesting)
+        """You are in a Test Layer (IntegrationTesting)
 that is fast by just aborting transactions between each test.
 You just committed something. That breaks the test isolation.
 So I stop here and let you fix it""")


### PR DESCRIPTION
I suspect this might break test in plone_coredev, but if it does, WITH GOOD REASON.
So break hell loose by merging this quick!    The button is here:
:arrow_down:

@saily @gforcada 