### PR TITLE
Use the canonical location of the SecurityPolicy.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ Changelog
 - Fix issue, which prevented using layered-helper on Python 3.
   [datakurre]
 
+- Fix ``.z2.Startup.setUpZCML()`` to be compatible with Zope >= 4.0a2.
+  [icemac]
+
 5.0.0 (2016-02-19)
 ------------------
 

--- a/src/plone/testing/z2.py
+++ b/src/plone/testing/z2.py
@@ -706,7 +706,7 @@ class Startup(Layer):
     <include package="Products.Five" />
     <meta:redefinePermission from="zope2.Public" to="zope.Public" />
 
-    <securityPolicy component="Products.Five.security.FiveSecurityPolicy" />
+    <securityPolicy component="AccessControl.security.SecurityPolicy" />
 
 </configure>
 """, context=context)


### PR DESCRIPTION
The previously used one is deprecated since Zope 2.12.0, see
https://github.com/zopefoundation/Zope/commit/8e409efafdcea1d86ada1832b3c76ea888f81ec2#diff-3e968b3ceaa7b185e8b1d65b1df63be5R30

It got removed in Zope 4.0a2.