### PR TITLE
Replace `ZServer.PubCore` handler with a threadless version.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,9 @@ New:
 
 Fixes:
 
-- *add item here*
+- Replace `ZServer.PubCore` handler with a threadless version, which fixes
+  `coverage` reporting.  See https://bitbucket.org/ned/coveragepy/issues/244.
+  [witsch]
 
 
 4.1.1 (2016-02-21)


### PR DESCRIPTION
This replaces the `ZServer.PubCore` handler (i.e. the `ZServerPublisher`/`ZRendezvous` loop) with a threadless version suitable for testing.  This allows complete `coverage` reporting, see https://bitbucket.org/ned/coveragepy/issues/244.