### PR TITLE
Fix for ZODB 5: Abort transaction before DB close (4.3.x backport)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fix for ZODB 5: Abort transaction before DB close.
+  [jensens, jimfulton, ale-rt]
+
 
 
 4.3.0 (2017-03-05)


### PR DESCRIPTION
same as #30 for 4.3.x branch, which is still used in buildout.coredev 5.1