### PR TITLE
Make compatible with the upcoming Zope 4.0b2.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@ Changelog
 - Update code to follow Plone styleguide.
   [gforcada]
 
+- Make compatible with ``Zope >= 4.0b2``.
+  [icemac]
+
 
 5.1.1 (2017-04-19)
 ------------------

--- a/src/plone/testing/z2.py
+++ b/src/plone/testing/z2.py
@@ -119,7 +119,7 @@ def uninstallProduct(app, productName, quiet=False):
             if ('Products.' + name) == productName:
 
                 if name in Application.misc_.__dict__:
-                    del Application.misc_.__dict__[name]
+                    delattr(Application.misc_, name)
 
                 try:
                     cp = app['Control_Panel']['Products']


### PR DESCRIPTION
This version uses a new style class for `misc_`.
These classes have a `dictproxy` instance on `__dict__` which does not support
item deletion.