### PR TITLE
Add the ``zpublisher_exception_hook`` to the Zope module on startup.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,16 @@ Bug fixes:
 - Update code to follow Plone styleguide.
   [gforcada]
 
+New Features:
+
+- add item here
+
+Bug Fixes:
+
+- Add the ``zpublisher_exception_hook`` to the Zope module on startup.
+  Now exceptions views are called on an exception during publishing, which was broken since Zope 4 doesn't startup the ZServer by default anymore.
+  [thet]
+
 
 5.1.1 (2017-04-19)
 ------------------

--- a/src/plone/testing/z2.py
+++ b/src/plone/testing/z2.py
@@ -626,6 +626,9 @@ class Startup(Layer):
         import Zope2
         Zope2.startup()
 
+        from ZServer.ZPublisher.exceptionhook import EXCEPTION_HOOK
+        setattr(Zope2, 'zpublisher_exception_hook', EXCEPTION_HOOK)
+
         # At this point, Zope2.DB is set to the test database facade. This is
         # the database will be used by default when someone does Zope2.app().
 


### PR DESCRIPTION
Now exceptions views are called on an exception during publishing, which was broken since Zope 4 doesn't startup the ZServer by default anymore.