### PR TITLE
Fix the Zope exception hook when using the ZServer layer.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ Bug fixes:
 
 - Fix most of the code smells Jenkins complains about.
 
+- Fix the Zope exception hook when using the ZServer layer.
+
 
 6.0.0 (2018-02-05)
 ------------------

--- a/src/plone/testing/z2.py
+++ b/src/plone/testing/z2.py
@@ -988,6 +988,7 @@ class ZServer(Layer):
 
         self._shutdown = False
 
+        self.setUpExceptionHook()
         self.setUpServer()
 
         self.thread = Thread(
@@ -1006,9 +1007,19 @@ class ZServer(Layer):
         time.sleep(0.5)
 
         self.tearDownServer()
+        self.tearDownExceptionHook()
 
         del self['host']
         del self['port']
+
+    def setUpExceptionHook(self):
+        from ZServer.ZPublisher.exceptionhook import EXCEPTION_HOOK
+        import Zope2
+        Zope2.zpublisher_exception_hook = EXCEPTION_HOOK
+
+    def tearDownExceptionHook(self):
+        import Zope2
+        Zope2.zpublisher_exception_hook = None
 
     def setUpServer(self):
         """Create a ZServer server instance and save it in self.zserver


### PR DESCRIPTION
Some plone.rest tests were failing because they use the ZServer layer and it was not setting up the Zope exception hook in Zope 4.