### PR TITLE
Pin ZODB to < 5.4.0 for now

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,9 @@ New features:
 
 Bug fixes:
 
+- Pinned ZODB to < 5.4.0 for testing to avoid flaky doctest layer teardowns.
+  [Rotonen]
+
 - Loosened doctest assertions to keep up with Zope-side changes.
   [Rotonen]
 

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -7,6 +7,9 @@ prefer-final = false
 setuptools =
 zc.buildout =
 plone.testing =
+# From 2018-10-02
+# Please remove this pinning after we get on top of the ZODB issues!
+ZODB = < 5.4.0
 
 [test]
 recipe = collective.xmltestreport


### PR DESCRIPTION
We're getting flaky doctest layer teardowns with the newest ZODB.

Pinning this down for now let's me get on with https://github.com/plone/plone.testing/pull/52