### PR TITLE
Enable picking a free port for ZServer layers automatically.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,9 @@ Changelog
 
 Breaking changes:
 
-- *add item here*
+- Default to picking a dynamical port for ZServer layers instead of a static
+  default port.
+  [Rotonen]
 
 New features:
 

--- a/src/plone/testing/z2.rst
+++ b/src/plone/testing/z2.rst
@@ -465,13 +465,7 @@ The ``ZSERVER`` layer provides a ``FunctionalTesting`` layer that has ``ZSERVER_
 After layer setup, the resources ``host`` and ``port`` are available, and indicate where Zope is running.::
 
     >>> host = z2.ZSERVER['host']
-    >>> host
-    'localhost'
-
     >>> port = z2.ZSERVER['port']
-    >>> import os
-    >>> port == int(os.environ.get('ZSERVER_PORT', 55001))
-    True
 
 Let's now simulate a test.
 Test setup does nothing beyond what the base layers do.::
@@ -569,13 +563,7 @@ The ``FTP_SERVER`` layer is based on ``FTP_SERVER_FIXTURE``, using the ``Functio
 After layer setup, the resources ``host`` and ``port`` are available, and indicate where Zope is running.::
 
     >>> host = z2.FTP_SERVER['host']
-    >>> host
-    'localhost'
-
     >>> port = z2.FTP_SERVER['port']
-    >>> import os
-    >>> port == int(os.environ.get('FTPSERVER_PORT', 55002))
-    True
 
 Let's now simulate a test.
 Test setup does nothing beyond what the base layers do.::


### PR DESCRIPTION
Backport of #52 on branch 4.3.x which is the branch be used by Plone 5.1.