### PR TITLE
The z2 extra should explicitly depend on ZServer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Explicitly depend on ZServer on the z2 extra.
+  [Rotonen]
 
 
 6.1.0 (2018-10-05)

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -10,6 +10,12 @@ plone.testing =
 # From 2018-10-02
 # Please remove this pinning after we get on top of the ZODB issues!
 ZODB = < 5.4.0
+# From 2018-10-06
+# Please remove this pinning once the Zope 4.0 stack allows for it!
+ZServer = < 4.0b3
+# From 2018-10-06
+# Please remove this pinning once collective.xmltestreport cuts a release!
+zope.testrunner = < 4.9.0
 
 [test]
 recipe = collective.xmltestreport

--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,7 @@ setup(
         ],
         'z2': [
             'Zope',
+            'ZServer',
             'zope.component',
             'zope.testbrowser',
             'zope.publisher',


### PR DESCRIPTION
As `Zope` does not seem to pull in `Zserver` anymore, our `[z2]` extra will need to depend on `ZServer` directly as otherwise anything doing Zope layers will not work.