### PR TITLE
set default ZPublisher encoding to utf-8

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Set default ZPublisher encoding to utf-8 to avoid encoding errors in testbrowser
+  [petschki]
 
 
 4.3.2 (2018-10-05)

--- a/src/plone/testing/z2.py
+++ b/src/plone/testing/z2.py
@@ -622,6 +622,11 @@ class Startup(Layer):
             del config.testinghome
             App.config.setConfiguration(config)
 
+        # set the default ZPublisher encoding to utf-8
+        # so data without encoding header is handled correctly...
+        from Zope2.Startup.datatypes import default_zpublisher_encoding
+        default_zpublisher_encoding('utf-8')
+
         # This uses the DB from the dbtab, as configured in setUpDatabase().
         # That DB then gets stored as Zope2.DB and becomes the default.
 

--- a/src/plone/testing/z2.rst
+++ b/src/plone/testing/z2.rst
@@ -383,6 +383,11 @@ We can now view this via the test browser:::
     >>> 'folder1' in browser.contents
     True
 
+Check if the default ZPublisher encoding is set to utf-8
+
+    >>> browser.headers['content-type']
+    'text/plain; charset=utf-8'
+
 The test browser integration converts the URL into a request and passes control to Zope's publisher.
 Let's check that query strings are available for input processing:::
 


### PR DESCRIPTION
this fixes tracebacks like

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 143, in publish
  Module zope.event, line 31, in notify
  Module zope.component.event, line 27, in dispatch
  Module zope.component._api, line 139, in subscribers
  Module zope.interface.registry, line 442, in subscribers
  Module zope.interface.adapter, line 607, in subscribers
  Module plone.transformchain.zpublisher, line 106, in applyTransformOnSuccess
  Module ZServer.HTTPResponse, line 267, in setBody
  Module ZPublisher.HTTPResponse, line 470, in setBody
  Module ZPublisher.HTTPResponse, line 654, in _encode_unicode
  Module encodings.iso8859_15, line 12, in encode
UnicodeEncodeError: 'charmap' codec can't encode character u'\u2014' in position 610: character maps to <undefined>
```

in zope testbrowser when no encoding header is found.

fixes #62 