### PR TITLE
Fix injection of ZopeLite test configuration into the global Zope configuration.

### DIFF
--- a/news/65.bugfix
+++ b/news/65.bugfix
@@ -1,0 +1,3 @@
+Fix injection of ZopeLite test configuration into the global Zope configuration.
+Fixes #64
+[thet]

--- a/src/plone/testing/zope.py
+++ b/src/plone/testing/zope.py
@@ -7,7 +7,6 @@ from plone.testing import Layer
 from plone.testing import zca
 from plone.testing import zodb
 from plone.testing._z2_testbrowser import Browser  # noqa
-from Testing.ZopeTestCase.ZopeLite import _patched as ZOPETESTCASEALERT
 from webtest.http import StopableWSGIServer
 from Zope2.App.schema import Zope2VocabularyRegistry
 from zope.schema.vocabulary import getVocabularyRegistry
@@ -461,6 +460,11 @@ class Startup(Layer):
         that the database that is opened by Zope 2 is in fact the top of
         the resource stack.
         """
+
+        # NOTE: Keep that import here.
+        #       Having it on module-level has the side effect of injecting the
+        #       ZopeLite test configuration into the global Zope configuration.
+        from Testing.ZopeTestCase.ZopeLite import _patched as ZOPETESTCASEALERT
         if ZOPETESTCASEALERT:
             raise Exception('You try to run plone.testing tests together with '
                             'ZopeTestCase tests. This will result in random '


### PR DESCRIPTION
Fixese #64