### PR TITLE
Fix `E902 FileNotFoundError`

### DIFF
--- a/news/74.bugfix
+++ b/news/74.bugfix
@@ -1,0 +1,1 @@
+- fix broken Flake8 job

--- a/tox.ini
+++ b/tox.ini
@@ -86,7 +86,7 @@ deps =
 commands =
     mkdir -p {toxinidir}/_build/reports/flake8
     - flake8 --format=html --htmldir={toxinidir}/_build/reports/flake8 --doctests src setup.py
-    flake8 --doctests --ignore=W503 src tests setup.py
+    flake8 --doctests --ignore=W503 src setup.py
     isort --check-only --recursive {toxinidir}/src
 
 whitelist_externals =


### PR DESCRIPTION
In its latest version, Flake8 now complains when it is called with a directory, which does not exist.

Here, Flake8 was called with `tests`, which is no top level directory.

modified:   tox.ini