### PR TITLE
Fix `clear_untrusted_proxy_headers` deprecation warning

### DIFF
--- a/news/77.bugfix
+++ b/news/77.bugfix
@@ -1,0 +1,1 @@
+fix waitress deprecation warning

--- a/src/plone/testing/zope.py
+++ b/src/plone/testing/zope.py
@@ -917,7 +917,7 @@ class WSGIServer(Layer):
         """Create a WSGI server instance and save it in self.server.
         """
         app = self.make_wsgi_app()
-        kwargs = {}
+        kwargs = {'clear_untrusted_proxy_headers': False}
         if self.host is not None:
             kwargs['host'] = self.host
         if self.port is not None:


### PR DESCRIPTION
Fixes...

DeprecationWarning: In future versions of Waitress
clear_untrusted_proxy_headers will be set to True by default. You may
opt-out by setting this value to False, or opt-in explicitly by setting
this to True.

fixes #77

Fix is analogous to https://github.com/plone/plone.recipe.zope2instance/issues/142