### PR TITLE
Catch FileNotFound error in teardown when removing temporary directory

### DIFF
--- a/news/79.bugfix
+++ b/news/79.bugfix
@@ -1,0 +1,3 @@
+Catch FileNotFound error in test teardown when removing a temporary directory.
+Fixes `issue 79 <https://github.com/plone/plone.testing/issues/79>`_.
+[maurits]

--- a/news/79.bugfix
+++ b/news/79.bugfix
@@ -1,3 +1,3 @@
-Catch FileNotFound error in test teardown when removing a temporary directory.
+Catch OSError in test teardown when removing a temporary directory.
 Fixes `issue 79 <https://github.com/plone/plone.testing/issues/79>`_.
 [maurits]

--- a/src/plone/testing/zope.py
+++ b/src/plone/testing/zope.py
@@ -937,7 +937,7 @@ class WSGIServer(Layer):
         self.server.shutdown()
         try:
             shutil.rmtree(self._wsgi_conf_dir)
-        except FileNotFoundError:
+        except OSError:
             pass
 
     def make_wsgi_app(self):

--- a/src/plone/testing/zope.py
+++ b/src/plone/testing/zope.py
@@ -935,7 +935,10 @@ class WSGIServer(Layer):
         """Close the server socket and clean up.
         """
         self.server.shutdown()
-        shutil.rmtree(self._wsgi_conf_dir)
+        try:
+            shutil.rmtree(self._wsgi_conf_dir)
+        except FileNotFoundError:
+            pass
 
     def make_wsgi_app(self):
         self._wsgi_conf_dir = tempfile.mkdtemp()


### PR DESCRIPTION
Fixes https://github.com/plone/plone.testing/issues/79.