### PR TITLE
Fix tests when run with ZODB 5.8.1+.

### DIFF
--- a/news/581.bugfix
+++ b/news/581.bugfix
@@ -1,0 +1,2 @@
+Fix tests when run with ZODB 5.8.1+.
+[maurits]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.towncrier]
-filename = "CHANGES.rst"
 directory = "news/"
+filename = "CHANGES.rst"
 title_format = "{version} ({project_date})"
 underlines = ["-", ""]
 
@@ -18,3 +18,21 @@ showcontent = true
 directory = "bugfix"
 name = "Bug fixes:"
 showcontent = true
+
+[[tool.towncrier.type]]
+directory = "internal"
+name = "Internal:"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "documentation"
+name = "Documentation:"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "tests"
+name = "Tests"
+showcontent = true
+
+[tool.isort]
+profile = "plone"

--- a/src/plone/testing/zodb.rst
+++ b/src/plone/testing/zodb.rst
@@ -53,7 +53,7 @@ Let's now simulate a test.::
 The test would then execute. It may use the ZODB root.::
 
     >>> zodb.EMPTY_ZODB['zodbConnection']
-    <Connection at ...>
+    <...Connection...at ...>
 
     >>> zodb.EMPTY_ZODB['zodbRoot']
     {}
@@ -136,7 +136,7 @@ Let's now simulate a test.::
 The test would then execute. It may use the ZODB root.::
 
     >>> POPULATED_ZODB['zodbConnection']
-    <Connection at ...>
+    <...Connection...at ...>
 
     >>> POPULATED_ZODB['zodbRoot']
     {'someData': 'a string'}
@@ -231,7 +231,7 @@ Let's now simulate a test.::
 The test would then execute. It may use the ZODB root.::
 
     >>> EXPANDED_ZODB['zodbConnection']
-    <Connection at ...>
+    <...Connection...at ...>
 
     >>> EXPANDED_ZODB['zodbRoot'] == dict(someData='a string', additionalData='Some new data')
     True


### PR DESCRIPTION
I have updated coredev 6.0 to temporarily extend Zope master versions.  But now I see locally that it leads to test failures:

```
Failure in test /Users/maurits/community/plone-coredev/6.0/src/plone.testing/src/plone/testing/zodb.rst
Failed doctest test for zodb.rst
  File "/Users/maurits/community/plone-coredev/6.0/src/plone.testing/src/plone/testing/zodb.rst", line 0

----------------------------------------------------------------------
File "/Users/maurits/community/plone-coredev/6.0/src/plone.testing/src/plone/testing/zodb.rst", line 55, in zodb.rst
Failed example:
    zodb.EMPTY_ZODB['zodbConnection']
Expected:
    <Connection at ...>
Got:
    <ZODB.Connection.Connection object at 0x1071e7f10>
----------------------------------------------------------------------
File "/Users/maurits/community/plone-coredev/6.0/src/plone.testing/src/plone/testing/zodb.rst", line 138, in zodb.rst
Failed example:
    POPULATED_ZODB['zodbConnection']
Expected:
    <Connection at ...>
Got:
    <ZODB.Connection.Connection object at 0x107256a10>
----------------------------------------------------------------------
File "/Users/maurits/community/plone-coredev/6.0/src/plone.testing/src/plone/testing/zodb.rst", line 233, in zodb.rst
Failed example:
    EXPANDED_ZODB['zodbConnection']
Expected:
    <Connection at ...>
Got:
    <ZODB.Connection.Connection object at 0x107268550>
```

That will be on Jenkins shortly as well.  This PR should fix it.

Note that currently the master branch and 8.x branch of `plone.testing` are stil the same.   The split was probably done by @gforcada when working on the still open PR #82.  We should look at that one again soonish.