### PR TITLE
Remove hard dependency on five.localsitemanager

### DIFF
--- a/news/86.bugfix
+++ b/news/86.bugfix
@@ -1,0 +1,1 @@
+Remove incorrect hard dependency on five.localsitemanager. @davisagli

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,7 @@ Zope = [
   'Products.CMFCore', 'Products.CMFDynamicViewFTI',
 ]
 python-dateutil = ['dateutil']
-ignore-packages = ['ZServer', 'StringIO', 'urllib2']
+ignore-packages = ['ZServer', 'StringIO', 'five.localsitemanager', 'urllib2']
 
 ##
 # Add extra configuration options in .meta.toml:

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ version = "9.0.1.dev0"
 install_requires = [
     "setuptools",
     "zope.testing >= 3.8",
-    "five.localsitemanager",
 ]
 
 tests_require = [


### PR DESCRIPTION
Fixes #86 

five.localsitemanager is only used via a conditional import, so it should not be listed as an install requirement.