### PR TITLE
Fix zope.uninstallProduct for Products installed with pip.

### DIFF
--- a/news/110.bugfix
+++ b/news/110.bugfix
@@ -1,0 +1,2 @@
+Fix ``zope.uninstallProduct`` for ``Products`` installed with pip.
+[maurits]

--- a/src/plone/testing/zope.py
+++ b/src/plone/testing/zope.py
@@ -129,19 +129,16 @@ def uninstallProduct(app, productName, quiet=False):
 
                 found = True
                 break
-    elif productName in _INSTALLED_PRODUCTS:  # must be a package
-        module, init_func = _INSTALLED_PRODUCTS[productName]
-        name = module.__name__
-
-        packages = get_packages_to_initialize()
-        packages.append((module, init_func))
+    if not found and productName in _INSTALLED_PRODUCTS:  # must be a package
+        if productName in Application.misc_.__dict__:
+            delattr(Application.misc_, productName)
         found = True
 
     if found:
         del _INSTALLED_PRODUCTS[productName]
 
     if not found and not quiet:
-        sys.stderr.write(f"Could not install product {productName}\n")
+        sys.stderr.write(f"Could not uninstall product {productName}\n")
         sys.stderr.flush()
 
 


### PR DESCRIPTION
In [PR 105](https://github.com/plone/plone.testing/pull/105) a few months ago I fixed `installProduct` for pip-installed packages in the `Products` namespace.  But a similar fix is needed in `uninstallProduct`. It is less of a problem there, but still the cleanup seems good to run.

Also fixed the message that you get when `uninstallProduct` is called on a product that *really* cannot be found.  Previously it would confusingly report "Could not install product", so "install" instead of "uninstall".

Also, the code that was run for uninstalling non-Products packages, was not really doing anything, or at least it was not cleaning up anything.  I have fixed that.